### PR TITLE
add a step to install required dependencies for node-canvas

### DIFF
--- a/setup/environment.md
+++ b/setup/environment.md
@@ -256,6 +256,14 @@ pod --version
 
 # LEVEL 2 - ReNative Developer
 
+## Install required dependencies for node-canvas
+
+https://github.com/Automattic/node-canvas
+
+```
+brew install pkg-config cairo pango libpng jpeg giflib librsvg
+```
+
 ## Install Yarn
 
 Unlocks `-p` : `web`, `chromecast`


### PR DESCRIPTION
 ## Description

- Bootstrapping on a new laptop fails because of node-canvas depencencies pixman, cairo and pango from brew. Make sure they are part of the wiki

## Related issues

- https://github.com/flexn-io/renative-docs/issues/6

